### PR TITLE
Simplify private DNS usage and disable zone redundancy

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -56,7 +56,6 @@ module "webapp" {
   appsvc_integration_subnet_id = module.network.appsvc_integration_snet_id
   pe_subnet_id                 = module.network.pe_snet_id
   web_zone_id                  = module.dns.web_zone_id
-  scm_zone_id                  = module.dns.scm_zone_id
   app_settings                 = {}
   tags                         = local.tags
 }

--- a/modules/acr/main.tf
+++ b/modules/acr/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_container_registry" "this" {
 
   network_rule_bypass_option    = "AzureServices"
   public_network_access_enabled = false
-  zone_redundancy_enabled       = true
+  zone_redundancy_enabled       = false
 }
 
 resource "azurerm_private_endpoint" "this" {

--- a/modules/appservice/plan/main.tf
+++ b/modules/appservice/plan/main.tf
@@ -13,5 +13,5 @@ resource "azurerm_service_plan" "this" {
   tags                = var.tags
 
   per_site_scaling_enabled = false
-  zone_balancing_enabled   = true
+  zone_balancing_enabled   = false
 }

--- a/modules/appservice/webapp/main.tf
+++ b/modules/appservice/webapp/main.tf
@@ -19,7 +19,6 @@ resource "azurerm_linux_web_app" "this" {
   site_config {
     always_on                               = true
     ftps_state                              = "Disabled"
-    health_check_path                       = "/health"
     minimum_tls_version                     = "1.2"
     container_registry_use_managed_identity = true
 
@@ -85,6 +84,6 @@ resource "azurerm_private_endpoint" "scm" {
 
   private_dns_zone_group {
     name                 = "scm-dns"
-    private_dns_zone_ids = [var.scm_zone_id]
+    private_dns_zone_ids = [var.web_zone_id]
   }
 }

--- a/modules/appservice/webapp/variables.tf
+++ b/modules/appservice/webapp/variables.tf
@@ -55,12 +55,7 @@ variable "pe_subnet_id" {
 
 variable "web_zone_id" {
   type        = string
-  description = "Private DNS zone ID for Web App."
-}
-
-variable "scm_zone_id" {
-  type        = string
-  description = "Private DNS zone ID for SCM site."
+  description = "Private DNS zone ID used for both Web App and SCM endpoints."
 }
 
 variable "app_settings" {

--- a/modules/private-dns/main.tf
+++ b/modules/private-dns/main.tf
@@ -12,9 +12,6 @@ locals {
     web = {
       name = "privatelink.azurewebsites.net"
     }
-    scm = {
-      name = "privatelink.scm.azurewebsites.net"
-    }
   }
 }
 

--- a/modules/private-dns/outputs.tf
+++ b/modules/private-dns/outputs.tf
@@ -8,7 +8,3 @@ output "web_zone_id" {
   value       = azurerm_private_dns_zone.this["web"].id
 }
 
-output "scm_zone_id" {
-  description = "Resource ID of the SCM private DNS zone."
-  value       = azurerm_private_dns_zone.this["scm"].id
-}


### PR DESCRIPTION
## Summary
- reuse a single private DNS zone for both web and SCM endpoints and update module wiring accordingly
- drop the web app health check path to avoid the missing eviction time error
- disable zone redundancy features on the container registry and app service plan to keep resources minimal

## Testing
- terraform fmt -recursive
- terraform -chdir=envs/dev init -backend=false
- terraform -chdir=envs/dev validate

------
https://chatgpt.com/codex/tasks/task_e_68ca3cee330c8332b678160417945c7b