### PR TITLE
Remove SCM private endpoint from web app module

### DIFF
--- a/modules/appservice/webapp/main.tf
+++ b/modules/appservice/webapp/main.tf
@@ -68,22 +68,3 @@ resource "azurerm_private_endpoint" "web" {
   }
 }
 
-resource "azurerm_private_endpoint" "scm" {
-  name                = "${var.app_name}-pep-scm"
-  location            = var.location
-  resource_group_name = var.rg_name
-  subnet_id           = var.pe_subnet_id
-  tags                = var.tags
-
-  private_service_connection {
-    name                           = "${var.app_name}-scm"
-    private_connection_resource_id = azurerm_linux_web_app.this.id
-    subresource_names              = ["scm"]
-    is_manual_connection           = false
-  }
-
-  private_dns_zone_group {
-    name                 = "scm-dns"
-    private_dns_zone_ids = [var.web_zone_id]
-  }
-}

--- a/modules/appservice/webapp/variables.tf
+++ b/modules/appservice/webapp/variables.tf
@@ -55,7 +55,7 @@ variable "pe_subnet_id" {
 
 variable "web_zone_id" {
   type        = string
-  description = "Private DNS zone ID used for both Web App and SCM endpoints."
+  description = "Private DNS zone ID used for the Web App private endpoint."
 }
 
 variable "app_settings" {


### PR DESCRIPTION
## Summary
- remove the SCM private endpoint from the app service web app module to avoid invalid group ID errors
- clarify the DNS zone variable description now that only the web endpoint is supported

## Testing
- terraform -chdir=envs/dev init -backend=false
- terraform -chdir=envs/dev validate

------
https://chatgpt.com/codex/tasks/task_e_68ca41b2719c8332b1958cc011a8241f