### PR TITLE
Use user-assigned managed identity for web app

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -42,22 +42,32 @@ module "appservice_plan" {
   tags      = local.tags
 }
 
+resource "azurerm_user_assigned_identity" "webapp" {
+  name                = "${var.app_name}-uami"
+  location            = var.location
+  resource_group_name = var.rg_app
+  tags                = local.tags
+}
+
 module "webapp" {
-  source                       = "../../modules/appservice/webapp"
-  rg_name                      = var.rg_app
-  location                     = var.location
-  plan_id                      = module.appservice_plan.plan_id
-  acr_id                       = module.acr.id
-  acr_login_server             = module.acr.login_server
-  app_name                     = var.app_name
-  image_repository             = var.image_repository
-  image_tag                    = var.image_tag
-  container_port               = var.container_port
-  appsvc_integration_subnet_id = module.network.appsvc_integration_snet_id
-  pe_subnet_id                 = module.network.pe_snet_id
-  web_zone_id                  = module.dns.web_zone_id
-  app_settings                 = {}
-  tags                         = local.tags
+  source                              = "../../modules/appservice/webapp"
+  rg_name                             = var.rg_app
+  location                            = var.location
+  plan_id                             = module.appservice_plan.plan_id
+  acr_id                              = module.acr.id
+  acr_login_server                    = module.acr.login_server
+  app_name                            = var.app_name
+  image_repository                    = var.image_repository
+  image_tag                           = var.image_tag
+  container_port                      = var.container_port
+  appsvc_integration_subnet_id        = module.network.appsvc_integration_snet_id
+  pe_subnet_id                        = module.network.pe_snet_id
+  web_zone_id                         = module.dns.web_zone_id
+  app_settings                        = {}
+  user_assigned_identity_id           = azurerm_user_assigned_identity.webapp.id
+  user_assigned_identity_client_id    = azurerm_user_assigned_identity.webapp.client_id
+  user_assigned_identity_principal_id = azurerm_user_assigned_identity.webapp.principal_id
+  tags                                = local.tags
 }
 
 output "acr_login_server" { value = module.acr.login_server }

--- a/modules/appservice/webapp/main.tf
+++ b/modules/appservice/webapp/main.tf
@@ -13,14 +13,16 @@ resource "azurerm_linux_web_app" "this" {
   tags                = var.tags
 
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [var.user_assigned_identity_id]
   }
 
   site_config {
-    always_on                               = true
-    ftps_state                              = "Disabled"
-    minimum_tls_version                     = "1.2"
-    container_registry_use_managed_identity = true
+    always_on                                     = true
+    ftps_state                                    = "Disabled"
+    minimum_tls_version                           = "1.2"
+    container_registry_use_managed_identity       = true
+    container_registry_managed_identity_client_id = var.user_assigned_identity_client_id
 
     application_stack {
       docker_image_name   = "${var.image_repository}:${var.image_tag}"
@@ -45,7 +47,7 @@ resource "azurerm_linux_web_app" "this" {
 resource "azurerm_role_assignment" "acr_pull" {
   scope                = var.acr_id
   role_definition_name = "AcrPull"
-  principal_id         = azurerm_linux_web_app.this.identity[0].principal_id
+  principal_id         = var.user_assigned_identity_principal_id
 }
 
 resource "azurerm_private_endpoint" "web" {

--- a/modules/appservice/webapp/outputs.tf
+++ b/modules/appservice/webapp/outputs.tf
@@ -4,6 +4,6 @@ output "app_name" {
 }
 
 output "principal_id" {
-  description = "System assigned identity principal ID for the Web App."
+  description = "Managed identity principal ID for the Web App."
   value       = azurerm_linux_web_app.this.identity[0].principal_id
 }

--- a/modules/appservice/webapp/variables.tf
+++ b/modules/appservice/webapp/variables.tf
@@ -64,6 +64,21 @@ variable "app_settings" {
   default     = {}
 }
 
+variable "user_assigned_identity_id" {
+  type        = string
+  description = "Resource ID of the user-assigned managed identity used by the Web App."
+}
+
+variable "user_assigned_identity_client_id" {
+  type        = string
+  description = "Client ID of the user-assigned managed identity used by the Web App."
+}
+
+variable "user_assigned_identity_principal_id" {
+  type        = string
+  description = "Principal ID of the user-assigned managed identity used by the Web App."
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to resources."


### PR DESCRIPTION
## Summary
- provision a user-assigned managed identity for the web app environment
- update the web app module to require the user-assigned identity for container registry access and AcrPull role
- expose new module inputs for the identity and keep outputs aligned with managed identity usage

## Testing
- terraform fmt -recursive
- terraform -chdir=envs/dev validate

------
https://chatgpt.com/codex/tasks/task_e_68ca4cebe1a8833295ef18f35cc53e53