### PR TITLE
Refine user-assigned identity naming

### DIFF
--- a/envs/dev/terraform.tfvars
+++ b/envs/dev/terraform.tfvars
@@ -1,7 +1,11 @@
 subscription_id = "6a3bb170-5159-4bff-860b-aa74fb762697"
 tenant_id       = "be945e7a-2e17-4b44-926f-512e85873eec"
 
-location = "westus3"
+location         = "westus3"
+org_code         = "vkp"
+project_code     = "orders"
+environment      = "dev"
+identity_purpose = "webapp"
 tags = {
   env   = "dev"
   owner = "vedant"

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -10,6 +10,33 @@ variable "location" {
   type = string
 }
 
+variable "org_code" {
+  description = "Short code that identifies the organization (for example, vkp)."
+  type        = string
+}
+
+variable "project_code" {
+  description = "Short code that identifies the workload or project the resources belong to."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment name (for example, dev, qa, prod)."
+  type        = string
+}
+
+variable "identity_purpose" {
+  description = "Describes what the user-assigned identity will be attached to (for example, webapp)."
+  type        = string
+  default     = "webapp"
+}
+
+variable "user_assigned_identity_name" {
+  description = "Optional override for the user-assigned identity resource name."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
## Summary
- introduce reusable naming context inputs for the user-assigned identity
- generate a standardized identity name with optional override support
- source the network module environment and tfvars from the new naming inputs

## Testing
- terraform -chdir=envs/dev fmt
- terraform -chdir=envs/dev init -backend=false
- terraform -chdir=envs/dev validate

------
https://chatgpt.com/codex/tasks/task_e_68ca5041283c83329ee15d922f07ef1f