### PR TITLE
Ensure UAMI creation waits for App Service resource group

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -76,8 +76,10 @@ module "appservice_plan" {
 resource "azurerm_user_assigned_identity" "webapp" {
   name                = local.user_assigned_identity_name
   location            = var.location
-  resource_group_name = var.rg_app
+  resource_group_name = module.appservice_plan.resource_group_name
   tags                = local.tags
+
+  depends_on = [module.appservice_plan]
 }
 
 module "webapp" {


### PR DESCRIPTION
## Summary
- ensure the user-assigned identity waits for the App Service plan module to complete by adding an explicit dependency

## Testing
- `terraform -chdir=envs/dev init`
- `terraform -chdir=envs/dev validate`


------
https://chatgpt.com/codex/tasks/task_e_68cae589ea7883329eb97558ea6b39e0