### PR TITLE
Handle null resource types in naming module

### DIFF
--- a/modules/naming/main.tf
+++ b/modules/naming/main.tf
@@ -50,11 +50,14 @@ locals {
         ),
         "-",
       )
-      resource_type = lookup(definition, "resource_type", "generic")
-      max_length = lookup(
-        definition,
-        "max_length",
-        lookup(local.default_max_length, lookup(definition, "resource_type", "generic"), 80),
+      resource_type = coalesce(lookup(definition, "resource_type", null), "generic")
+      max_length = coalesce(
+        lookup(definition, "max_length", null),
+        lookup(
+          local.default_max_length,
+          coalesce(lookup(definition, "resource_type", null), "generic"),
+          80,
+        ),
       )
     }
   }


### PR DESCRIPTION
## Summary
- default the naming module resource_type to "generic" when the input provides null
- fall back to max length defaults when resource definitions omit a value

## Testing
- terraform validate *(fails: terraform executable is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf6c315148332b83cdff9e83326c1