### PR TITLE
Allow destroying resource groups containing unmanaged resources

### DIFF
--- a/envs/dev/versions.tf
+++ b/envs/dev/versions.tf
@@ -10,7 +10,11 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 
   subscription_id = var.subscription_id
   tenant_id       = var.tenant_id


### PR DESCRIPTION
## Summary
- disable AzureRM provider safeguard that blocks deleting resource groups with nested resources

## Testing
- terraform fmt

------
https://chatgpt.com/codex/tasks/task_e_68cb366e659083329236d9eb92541de0