### PR TITLE
Disable provider registration attempts

### DIFF
--- a/envs/dev/.terraform.lock.hcl
+++ b/envs/dev/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.6.1"
+  constraints = ">= 1.12.0"
+  hashes = [
+    "h1:mMkfr2ZCRGP0uQl/KS5V1wkpyGx2ebdREKPv70QGDDA=",
+    "zh:079ae1e32ddfc8adff953653bae29e755c1b170f09d39c156af849c7211796fe",
+    "zh:167083f1afb594943a7ce15c1321514d0b49e61239dd72501562cb344542cd7f",
+    "zh:3e534fb7c77ee4b6f6f0ff4ae72052741a865919ebe4ed7565ed50664843441d",
+    "zh:70c0cf7e98f8b09627b99babdb8b88a474c4b3c4cdeedacb3db1cef6850cb87c",
+    "zh:770263c99f6215d4b51e464319b5527f32231ee3b9be8b47b4586614d66ef6d2",
+    "zh:9695b9edf68baf6062d131c771acd0446493200dbefa83a818a5cda445f6f416",
+    "zh:9e36055ed2a5d4d1fad18ab0baa54b2033e824b675966bfaf1293fb5153b028e",
+    "zh:9f0f1949d69008f5dd9ea47a5b7bf81f89e8cf81df8175e44899acbffa6db97b",
+    "zh:a9905e45c32fa9f1ce1fe199b9d01d885e3bb1959290224fd12c0e1971a71c1d",
+    "zh:e1bcb4f0bdb578bbc49780a0019dd7b26d291ad79da414c7b012ebcd4b6e961d",
+    "zh:eba871271888de8f16fbbc9f138658875031253d3fb5feeeea8c8165dc26a86e",
+    "zh:f2b04c71796d1ec2528c460bad7abe943ce120d3d5c6ef7bee66655dd8db44a1",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.44.0"
   constraints = ">= 4.9.0"

--- a/envs/dev/versions.tf
+++ b/envs/dev/versions.tf
@@ -20,10 +20,11 @@ provider "azurerm" {
     }
   }
 
-  subscription_id = var.subscription_id
-  tenant_id       = var.tenant_id
-  client_id       = var.spoke_client_id
-  client_secret   = var.spoke_client_secret
+  subscription_id                 = var.subscription_id
+  tenant_id                       = var.tenant_id
+  client_id                       = var.spoke_client_id
+  client_secret                   = var.spoke_client_secret
+  resource_provider_registrations = "none"
 }
 
 provider "azurerm" {
@@ -31,10 +32,11 @@ provider "azurerm" {
 
   features {}
 
-  subscription_id = var.hub_subscription_id
-  tenant_id       = var.hub_tenant_id
-  client_id       = var.hub_client_id
-  client_secret   = var.hub_client_secret
+  subscription_id                 = var.hub_subscription_id
+  tenant_id                       = var.hub_tenant_id
+  client_id                       = var.hub_client_id
+  client_secret                   = var.hub_client_secret
+  resource_provider_registrations = "none"
 }
 
 provider "azapi" {


### PR DESCRIPTION
## Summary
- disable automatic Azure Resource Provider registration in both azurerm provider blocks to avoid permission errors
- refresh the Terraform dependency lock file after reinitializing providers

## Testing
- terraform -chdir=envs/dev init -backend=false
- terraform -chdir=envs/dev validate

------
https://chatgpt.com/codex/tasks/task_e_68cb8e751c088332bc2d3058130aa3f2