### PR TITLE
docs: clarify auth and update runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,140 @@
 # Hub-and-Spoke Network Peering with Private DNS Forwarding
 
-## Purpose
-This Terraform configuration provisions a spoke virtual network, peering, and application infrastructure that integrates with an existing hub subscription. The spoke VNet is configured to use the hub virtual network gateway for VPN connectivity and the hub Private DNS Resolver for name resolution, ensuring that application private endpoints and DNS traffic remain on the private backbone.
+## Overview
+This repository contains a reusable Terraform implementation of a spoke environment that plugs into an existing hub subscription. Running the configuration builds:
 
-## Multi-tenant Authentication Model
-Authenticate to Azure locally (for example, with `az login`) before running Terraform. The configuration reuses your CLI session for **both** the spoke and hub subscriptions via provider aliases (`azurerm.hub` and `azapi.hub`).
+- A spoke virtual network with subnets for App Service integration and private endpoints
+- Bidirectional VNet peering to an existing hub virtual network with gateway transit enabled
+- Private DNS zones that link back to the hub to centralise name resolution
+- Azure Container Registry, App Service plan, user-assigned identity, and two container-based web apps
 
-- `provider "azurerm"` targets the spoke subscription while honouring your CLI credentials.
-- `provider "azurerm" { alias = "hub" }` switches the subscription ID but keeps the same logged-in principal. Auxiliary tenant IDs are configured automatically so cross-tenant peering and Private DNS links succeed when your account is a guest in the hub tenant.
+The goal is to allow any team to deploy an application stack that inherits shared networking services (VPN gateway, Private DNS resolver) provided in the hub subscription.
+
+## Repository Layout
+The repo is split into composable Terraform modules and environment-specific entry points:
+
+| Path | Purpose |
+|------|---------|
+| `envs/dev/` | Example environment. Contains the root Terraform configuration (`main.tf`), provider declarations (`versions.tf`), and environment defaults (`terraform.tfvars`). Copy this folder when creating a new environment. |
+| `modules/naming` | Generates consistent resource names based on organisation, project, environment, and location tokens. |
+| `modules/network` | Creates the spoke virtual network, subnets, and associated resource group. |
+| `modules/private-dns` | Creates Private DNS zones and links them to the spoke and hub VNets. |
+| `modules/acr` | Provisions Azure Container Registry with private endpoint integration. |
+| `modules/appservice/*` | Contains submodules for the App Service plan and web apps. |
+
+When modifying or extending the infrastructure, update `envs/<environment>/main.tf` to wire additional modules, adjust or override variables in `variables.tf` and `terraform.tfvars`, and add new reusable building blocks under `modules/` as needed.
+
+## Prerequisites
+- Terraform CLI `>= 1.7.0`
+- Azure CLI `>= 2.50` (used for authentication and role assignments)
+- Access to both the spoke and hub Azure subscriptions
+- Permission to create Azure AD service principals
+
+## Authentication & Service Principal Requirements
+Terraform authenticates with explicit client credentials supplied through variables (`client_id`, `client_secret`, `tenant_id`, and `subscription_id`). The same identity is re-used with provider aliases to operate in the hub subscription.
+
+### 1. Create (or reuse) a service principal for automation
+Run once per environment or workload. Replace placeholder values with your own identifiers.
+
+```bash
+# Log in with an identity that can create service principals
+az login
+
+# Define variables for readability
+SPOKE_SUBSCRIPTION="<spoke-subscription-guid>"
+HUB_SUBSCRIPTION="<hub-subscription-guid>"
+HUB_VNET_SCOPE="/subscriptions/${HUB_SUBSCRIPTION}/resourceGroups/<hub-rg>/providers/Microsoft.Network/virtualNetworks/<hub-vnet-name>"
+STATE_SCOPE="/subscriptions/${SPOKE_SUBSCRIPTION}/resourceGroups/<state-rg>/providers/Microsoft.Storage/storageAccounts/<state-storage-account>"
+SP_NAME="sp-terraform-hub-spoke"
+
+# Create the service principal with Contributor on the spoke subscription
+az ad sp create-for-rbac \
+  --name "${SP_NAME}" \
+  --role Contributor \
+  --scopes "/subscriptions/${SPOKE_SUBSCRIPTION}"
+```
+
+Record the `appId`, `password`, and `tenant` values from the output. They correspond to `client_id`, `client_secret`, and `tenant_id` in Terraform.
+
+### 2. Grant required roles on shared resources
+The same service principal needs additional rights to interact with hub networking components and (optionally) the remote state storage account.
+
+```bash
+# Allow the service principal to manage peering on the hub VNet
+az role assignment create \
+  --assignee "${SP_NAME}" \
+  --role "Network Contributor" \
+  --scope "${HUB_VNET_SCOPE}"
+
+# Permit reading VNet information (included in Network Contributor),
+# and linking Private DNS zones during deployment
+az role assignment create \
+  --assignee "${SP_NAME}" \
+  --role "Reader" \
+  --scope "/subscriptions/${HUB_SUBSCRIPTION}"
+
+# Optional: enable Terraform to read/write state in an Azure Storage container
+az role assignment create \
+  --assignee "${SP_NAME}" \
+  --role "Storage Blob Data Contributor" \
+  --scope "${STATE_SCOPE}"
+```
+
+> **Summary of required permissions**
+>
+> - **Spoke subscription:** `Contributor` (allows resource group, network, DNS, and App Service provisioning)
+> - **Hub virtual network scope:** `Network Contributor` (allows creation of the hub-to-spoke peering and DNS links)
+> - **Hub subscription (optional but recommended):** `Reader` (allows discovery of hub assets through data sources)
+> - **Remote state storage (if used):** `Storage Blob Data Contributor`
+
+### 3. Configure Terraform authentication
+Provide the captured credentials to Terraform through a `.tfvars` file or environment variables:
+
+```bash
+export ARM_CLIENT_ID="<appId>"
+export ARM_CLIENT_SECRET="<password>"
+export ARM_TENANT_ID="<tenant>"
+export ARM_SUBSCRIPTION_ID="${SPOKE_SUBSCRIPTION}"
+
+# Auxiliary tenant IDs allow the provider aliases to request tokens for the hub tenant
+export ARM_AUXILIARY_TENANT_IDS="<hub-tenant-guid>"
+```
+
+Alternatively, populate `client_id`, `client_secret`, `tenant_id`, `subscription_id`, `hub_subscription_id`, and `hub_tenant_id` directly in `terraform.tfvars`. Avoid committing secrets to version control—use a local `.auto.tfvars` file or environment variables with `terraform apply -var "client_secret=$ARM_CLIENT_SECRET"`.
+
+## Working with Environments
+Each environment folder under `envs/` acts as an independent Terraform state. To create a new environment:
+
+1. Copy `envs/dev` to `envs/<new-env>`.
+2. Update `terraform.tfvars` with the new subscription IDs, tenant IDs, naming tokens, CIDR ranges, and container image details.
+3. Review `variables.tf` for any new variables you might need. Add them to the module interfaces if new functionality is introduced.
+4. Modify `main.tf` to add or remove modules/resources for the workload. For example, add a new module block to provision additional private endpoints, or adjust `module "network"` settings to change subnet ranges.
 
 ## Running Terraform
-1. Navigate to the desired environment folder, e.g. `envs/dev/`.
-2. Copy `backend-config.example.hcl` to `backend-config.hcl` and adjust if you use remote state.
-3. Provide required values using `terraform.tfvars`, a `.auto.tfvars` file, or environment variables.
-4. Initialise providers and modules:
-   ```bash
-   terraform init [-backend-config=backend-config.hcl]
-   ```
-5. Review the execution plan:
-   ```bash
-   terraform plan -out=tfplan
-   ```
-6. Apply the plan when ready:
-   ```bash
-   terraform apply tfplan
-   ```
+The `terraform-commands.txt` file contains an expanded, copy-paste friendly command list. The high-level workflow is:
 
-## Key Variables
-- `subscription_id`, `tenant_id`: Identify the spoke subscription that owns the workload resources.
-- `hub_subscription_id`, `hub_tenant_id`: Identify the shared hub subscription. The tenant ID is required when you are a guest user in the hub tenant so Terraform can request auxiliary tokens.
-- `hub_resource_group_name`, `hub_vnet_name`: Identify the shared hub network.
-- `hub_private_dns_resolver_name`, `hub_private_dns_resolver_inbound_endpoint_name`: Used to query the hub Private DNS Resolver inbound endpoint IPs dynamically. If discovery fails, Terraform falls back to `hub_private_dns_resolver_static_ips` and ultimately to `hub_private_dns_resolver_fallback_ip` (default `11.0.1.68`).
-- `spoke_to_hub_peering_name`, `hub_to_spoke_peering_name`: Control peering resource names.
+1. Navigate to the environment folder: `cd envs/dev`
+2. (Optional) configure remote state via `backend-config.hcl`
+3. Initialise providers and modules: `terraform init`
+4. Validate syntax: `terraform validate`
+5. Plan changes: `terraform plan -out=tfplan`
+6. Apply the saved plan: `terraform apply tfplan`
+7. Inspect outputs: `terraform output`
+8. Destroy (when needed): `terraform destroy -auto-approve`
 
-See `envs/dev/terraform.tfvars` for an example of how to populate the identifiers while keeping real secrets external to source control.
+## Modifying or Extending the Infrastructure
+When new requirements appear:
 
-## DNS and Networking Flow
-1. Terraform peers the spoke VNet to the hub VNet and enables gateway transit so the hub VPN gateway is reused.
-2. The spoke VNet DNS servers are set to the Private DNS Resolver inbound endpoint IPs retrieved from the hub (or the configured fallback).
-3. Private DNS zones remain owned by the spoke subscription for private endpoint integration, but they link only to the hub VNet. This keeps DNS resolution centralised in the hub while still enabling automatic record creation by private endpoints.
+- **Add a new Azure resource type:** create a module under `modules/` encapsulating that resource, expose variables for customisation, then call the module from `envs/<environment>/main.tf`.
+- **Change naming conventions:** update `modules/naming` or provide overrides via the `naming_overrides` variable.
+- **Alter networking:** adjust `module "network"` inputs (for example, CIDR ranges) and confirm any dependencies in downstream modules.
+- **Adjust application container settings:** change the image repositories, tags, and port numbers in `terraform.tfvars` or promote them to variables if they vary per environment.
 
-## User Story
-> As a developer onboarding a new workload, I want Terraform to set up my spoke environment so that I can deploy applications privately. When I run the configuration, it builds my spoke VNet, peers it with the company hub, points my DNS to the hub resolver, and links any private endpoints back through the hub. After one apply I can connect through the existing VPN and resolve internal resources without exposing anything to the public internet.
+Keeping changes modular makes it easier for reviewers and future engineers to understand the blast radius. Whenever you add variables, document them in the README or inline comments, and update `terraform.tfvars` examples so other teams know how to configure new functionality.
 
-With this workflow in place, new engineers sign in with the Azure CLI, supply the required subscription identifiers, run the documented Terraform commands, and gain a fully integrated spoke that respects the organisation's shared hub-and-spoke networking standards.
+## Troubleshooting
+- **Authentication failures:** verify the service principal credentials and role assignments. Use `az account get-access-token --resource https://management.azure.com/ --query expiresOn` to ensure the identity can obtain tokens for both tenants.
+- **Peering errors:** confirm the hub virtual network scope in the `Network Contributor` role assignment matches the exact hub VNet ID.
+- **Private DNS linking issues:** ensure the hub subscription/tenant IDs are correctly set and that the identity has rights to join VNets across tenants.
+
+With these practices, onboarding engineers can confidently understand the deployment topology, authenticate Terraform correctly, and know where to make modifications when introducing new resources.

--- a/terraform-commands.txt
+++ b/terraform-commands.txt
@@ -1,84 +1,95 @@
-# ----------------------------------------------------
-# 0. (One-time) Ensure the remote state container exists
-# ----------------------------------------------------
-# Authenticate with Azure using Azure AD (CLI or Service Principal) before
-# provisioning the backend container or running Terraform commands.
-# az login --tenant 6a3bb170-5159-4bff-860b-aa74fb762697
-# az account set --subscription 6a3bb170-5159-4bff-860b-aa74fb762697
-#
-# Create the storage container if it does not already exist. Account keys are
-# disabled on the storage account so use Azure AD auth via the CLI.
-# az storage container create \
-#   --account-name storageaccountvp \
-#   --name tfstate \
-#   --auth-mode login \
-#   --public-access off
-#
-# Ensure the user or service principal that will run Terraform has a role with
-# data plane access to the container (for example, Storage Blob Data
-# Contributor). Replace <principal-id> with the object ID of your identity.
-# az role assignment create \
-#   --assignee-object-id <principal-id> \
-#   --assignee-principal-type User \
-#   --role "Storage Blob Data Contributor" \
-#   --scope "/subscriptions/6a3bb170-5159-4bff-860b-aa74fb762697/resourceGroups/Wordpress-PHP/providers/Microsoft.Storage/storageAccounts/storageaccountvp"
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
+# 0. Bootstrap authentication (run once)
+# -----------------------------------------------------------------------------
+# Create or reuse the service principal that Terraform will use. Replace the
+# placeholder values with your identifiers. See README.md for detailed context.
+az login
 
-# ----------------------------------------------------
+SPOKE_SUBSCRIPTION="<spoke-subscription-guid>"
+HUB_SUBSCRIPTION="<hub-subscription-guid>"
+HUB_VNET_SCOPE="/subscriptions/${HUB_SUBSCRIPTION}/resourceGroups/<hub-rg>/providers/Microsoft.Network/virtualNetworks/<hub-vnet-name>"
+STATE_SCOPE="/subscriptions/${SPOKE_SUBSCRIPTION}/resourceGroups/<state-rg>/providers/Microsoft.Storage/storageAccounts/<state-storage-account>"
+SP_NAME="sp-terraform-hub-spoke"
+
+# Create the service principal with Contributor on the spoke subscription
+az ad sp create-for-rbac \
+  --name "${SP_NAME}" \
+  --role Contributor \
+  --scopes "/subscriptions/${SPOKE_SUBSCRIPTION}"
+
+# Allow Terraform to manage the hub-to-spoke peering
+az role assignment create \
+  --assignee "${SP_NAME}" \
+  --role "Network Contributor" \
+  --scope "${HUB_VNET_SCOPE}"
+
+# Optional but recommended: enable read access to the hub subscription
+az role assignment create \
+  --assignee "${SP_NAME}" \
+  --role "Reader" \
+  --scope "/subscriptions/${HUB_SUBSCRIPTION}"
+
+# Optional: grant access to a remote state storage account/container
+az role assignment create \
+  --assignee "${SP_NAME}" \
+  --role "Storage Blob Data Contributor" \
+  --scope "${STATE_SCOPE}"
+
+# Export the captured credentials so Terraform can authenticate
+export ARM_CLIENT_ID="<appId>"
+export ARM_CLIENT_SECRET="<password>"
+export ARM_TENANT_ID="<tenant>"
+export ARM_SUBSCRIPTION_ID="${SPOKE_SUBSCRIPTION}"
+export ARM_AUXILIARY_TENANT_IDS="<hub-tenant-guid>"
+
+# -----------------------------------------------------------------------------
 # 1. Navigate to your environment folder
-# ----------------------------------------------------
-cd C:\Users\Vedant Patel\Desktop\terraform_infra\envs\dev
+# -----------------------------------------------------------------------------
+cd /path/to/terraform_infra/envs/dev
 
-
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 # 2. Initialize Terraform
 # (Downloads provider plugins, configures backend in Azure Storage)
 # With backend values in envs/dev/backend.tf you can run init directly.
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 terraform init
 
-
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 # 3. Validate configuration
 # (Quick syntax + structural check of your .tf files)
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 terraform validate
 
-
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 # 4. Preview changes
 # (Shows what Terraform will CREATE/UPDATE/DESTROY in Azure)
 # The -out=tfplan flag saves the plan to a file for consistent apply
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 terraform plan -out=tfplan
 
-
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 # 5. Apply changes
 # (Executes the saved plan and provisions resources in Azure)
 # Always use the saved plan so you know exactly what’s applied
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 terraform apply "tfplan"
 
-
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 # 6. Check outputs (optional)
 # (Shows any outputs defined in your main.tf for quick reference)
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 terraform output
 
-
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 # 7. Update infrastructure later
 # (Repeat plan+apply after editing variables.tfvars or modules)
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 terraform plan -out=tfplan
 terraform apply "tfplan"
 
-
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 # 8. Destroy resources
 # (Removes everything defined in this environment’s state file)
 # Use with caution! This will delete all managed Azure resources.
-# ----------------------------------------------------
+# -----------------------------------------------------------------------------
 terraform destroy -auto-approve


### PR DESCRIPTION
## Summary
- document the repository structure and workflow for extending the hub-and-spoke environment
- add detailed Azure AD service principal setup steps, authentication guidance, and role requirements
- refresh the Terraform runbook with bootstrap commands for creating the service principal and exporting credentials

## Testing
- no automated tests were run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cc93ff899483329853adf5a9e18b24