### PR TITLE
Configure auxiliary tenant support for dev networking

### DIFF
--- a/infra-core/dev/versions.tf
+++ b/infra-core/dev/versions.tf
@@ -20,6 +20,9 @@ provider "azurerm" {
   tenant_id       = var.spoke_tenant_id
   client_id       = var.client_id
   client_secret   = var.client_secret
+  auxiliary_tenant_ids = [
+    var.hub_tenant_id,
+  ]
 }
 
 provider "azurerm" {
@@ -30,4 +33,7 @@ provider "azurerm" {
   tenant_id       = var.hub_tenant_id
   client_id       = var.client_id
   client_secret   = var.client_secret
+  auxiliary_tenant_ids = [
+    var.spoke_tenant_id,
+  ]
 }


### PR DESCRIPTION
## Summary
- include auxiliary tenant IDs on both AzureRM provider blocks used by the dev core infrastructure
- enable cross-tenant authorization required for hub and spoke virtual network peering creation

## Testing
- terraform fmt *(fails: terraform not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd73ce6988332ac0993946871a07b