### PR TITLE
Configure infra-core state backend in Azure Storage

### DIFF
--- a/infra-core/common/backend.tf
+++ b/infra-core/common/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "TerraformStorageAccount"
+    storage_account_name = "terrsaform"
+    container_name       = "terraform"
+    key                  = "infra-core/common/terraform.tfstate"
+  }
+}

--- a/infra-core/dev/backend.tf
+++ b/infra-core/dev/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "TerraformStorageAccount"
+    storage_account_name = "terrsaform"
+    container_name       = "terraform"
+    key                  = "infra-core/dev/terraform.tfstate"
+  }
+}

--- a/infra-core/prod/backend.tf
+++ b/infra-core/prod/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "TerraformStorageAccount"
+    storage_account_name = "terrsaform"
+    container_name       = "terraform"
+    key                  = "infra-core/prod/terraform.tfstate"
+  }
+}


### PR DESCRIPTION
## Summary
- configure each infra-core environment to use the shared Azure Storage account for Terraform state
- assign unique state keys per environment within the storage container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce025beb848332aa7a07298e20e971