### PR TITLE
Configure infra-core remote state backend

### DIFF
--- a/infra-core/common/versions.tf
+++ b/infra-core/common/versions.tf
@@ -7,6 +7,15 @@ terraform {
       version = ">= 4.9.0"
     }
   }
+
+  backend "azurerm" {
+    resource_group_name  = "TerraformStorageAccount"
+    storage_account_name = "terrsaform"
+    container_name       = "terraform"
+    key                  = "infra-core-common.tfstate"
+
+    use_azuread_auth = true
+  }
 }
 
 provider "azurerm" {

--- a/infra-core/dev/versions.tf
+++ b/infra-core/dev/versions.tf
@@ -7,6 +7,15 @@ terraform {
       version = ">= 4.9.0"
     }
   }
+
+  backend "azurerm" {
+    resource_group_name  = "TerraformStorageAccount"
+    storage_account_name = "terrsaform"
+    container_name       = "terraform"
+    key                  = "infra-core-dev.tfstate"
+
+    use_azuread_auth = true
+  }
 }
 
 provider "azurerm" {

--- a/infra-core/prod/versions.tf
+++ b/infra-core/prod/versions.tf
@@ -7,6 +7,15 @@ terraform {
       version = ">= 4.9.0"
     }
   }
+
+  backend "azurerm" {
+    resource_group_name  = "TerraformStorageAccount"
+    storage_account_name = "terrsaform"
+    container_name       = "terraform"
+    key                  = "infra-core-prod.tfstate"
+
+    use_azuread_auth = true
+  }
 }
 
 provider "azurerm" {


### PR DESCRIPTION
## Summary
- configure the infra-core common, dev, and prod Terraform configurations to use the shared terrsaform storage account container for state
- enable Azure AD authentication on the backend so the existing service principal can be used to access the remote state

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce034a15d883329ff4b36bd3916e56