### PR TITLE
Configure backend to use service principal auth

### DIFF
--- a/infra-core/common/versions.tf
+++ b/infra-core/common/versions.tf
@@ -15,6 +15,10 @@ terraform {
     key                  = "infra-core-common.tfstate"
 
     use_azuread_auth = true
+    subscription_id  = var.subscription_id
+    tenant_id        = var.tenant_id
+    client_id        = var.client_id
+    client_secret    = var.client_secret
   }
 }
 

--- a/infra-core/dev/versions.tf
+++ b/infra-core/dev/versions.tf
@@ -15,6 +15,10 @@ terraform {
     key                  = "infra-core-dev.tfstate"
 
     use_azuread_auth = true
+    subscription_id  = var.spoke_subscription_id
+    tenant_id        = var.spoke_tenant_id
+    client_id        = var.client_id
+    client_secret    = var.client_secret
   }
 }
 

--- a/infra-core/prod/versions.tf
+++ b/infra-core/prod/versions.tf
@@ -15,6 +15,10 @@ terraform {
     key                  = "infra-core-prod.tfstate"
 
     use_azuread_auth = true
+    subscription_id  = var.spoke_subscription_id
+    tenant_id        = var.spoke_tenant_id
+    client_id        = var.client_id
+    client_secret    = var.client_secret
   }
 }
 


### PR DESCRIPTION
## Summary
- configure each infra-core workspace backend to authenticate with the shared service principal credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce05a7378883328c92ae11ceccb332