### PR TITLE
Ensure backend uses shared service principal credentials

### DIFF
--- a/infra-core/common/versions.tf
+++ b/infra-core/common/versions.tf
@@ -14,6 +14,8 @@ terraform {
     container_name       = "terraform"
     key                  = "infra-core-common.tfstate"
 
+    # Use the same service principal credentials as the providers so the
+    # remote state storage account is accessed with the shared identity.
     use_azuread_auth = true
     subscription_id  = var.subscription_id
     tenant_id        = var.tenant_id

--- a/infra-core/dev/versions.tf
+++ b/infra-core/dev/versions.tf
@@ -14,6 +14,8 @@ terraform {
     container_name       = "terraform"
     key                  = "infra-core-dev.tfstate"
 
+    # Use the same service principal credentials as the providers so the
+    # remote state storage account is accessed with the shared identity.
     use_azuread_auth = true
     subscription_id  = var.spoke_subscription_id
     tenant_id        = var.spoke_tenant_id

--- a/infra-core/prod/versions.tf
+++ b/infra-core/prod/versions.tf
@@ -14,6 +14,8 @@ terraform {
     container_name       = "terraform"
     key                  = "infra-core-prod.tfstate"
 
+    # Use the same service principal credentials as the providers so the
+    # remote state storage account is accessed with the shared identity.
     use_azuread_auth = true
     subscription_id  = var.spoke_subscription_id
     tenant_id        = var.spoke_tenant_id


### PR DESCRIPTION
## Summary
- clarify in each infra-core environment that the azurerm backend uses the same service principal credentials as the providers

## Testing
- terraform fmt -recursive infra-core/common infra-core/dev infra-core/prod
- (cd infra-core/common && terraform init -backend=false)
- (cd infra-core/common && terraform validate)
- (cd infra-core/dev && terraform init -backend=false)
- (cd infra-core/dev && terraform validate)
- (cd infra-core/prod && terraform init -backend=false)
- (cd infra-core/prod && terraform validate)


------
https://chatgpt.com/codex/tasks/task_e_68ce06a72fe48332a50550b8dd304162