### PR TITLE
Fix backend auth configuration to avoid variable usage

### DIFF
--- a/infra-core/common/versions.tf
+++ b/infra-core/common/versions.tf
@@ -14,13 +14,10 @@ terraform {
     container_name       = "terraform"
     key                  = "infra-core-common.tfstate"
 
-    # Use the same service principal credentials as the providers so the
-    # remote state storage account is accessed with the shared identity.
+    # The backend uses Azure AD authentication.  Credentials should be
+    # supplied via environment variables or `-backend-config` arguments when
+    # running `terraform init`.
     use_azuread_auth = true
-    subscription_id  = var.subscription_id
-    tenant_id        = var.tenant_id
-    client_id        = var.client_id
-    client_secret    = var.client_secret
   }
 }
 

--- a/infra-core/dev/versions.tf
+++ b/infra-core/dev/versions.tf
@@ -14,13 +14,10 @@ terraform {
     container_name       = "terraform"
     key                  = "infra-core-dev.tfstate"
 
-    # Use the same service principal credentials as the providers so the
-    # remote state storage account is accessed with the shared identity.
+    # The backend uses Azure AD authentication.  Credentials should be
+    # supplied via environment variables or `-backend-config` arguments when
+    # running `terraform init`.
     use_azuread_auth = true
-    subscription_id  = var.spoke_subscription_id
-    tenant_id        = var.spoke_tenant_id
-    client_id        = var.client_id
-    client_secret    = var.client_secret
   }
 }
 

--- a/infra-core/prod/versions.tf
+++ b/infra-core/prod/versions.tf
@@ -14,13 +14,10 @@ terraform {
     container_name       = "terraform"
     key                  = "infra-core-prod.tfstate"
 
-    # Use the same service principal credentials as the providers so the
-    # remote state storage account is accessed with the shared identity.
+    # The backend uses Azure AD authentication.  Credentials should be
+    # supplied via environment variables or `-backend-config` arguments when
+    # running `terraform init`.
     use_azuread_auth = true
-    subscription_id  = var.spoke_subscription_id
-    tenant_id        = var.spoke_tenant_id
-    client_id        = var.client_id
-    client_secret    = var.client_secret
   }
 }
 


### PR DESCRIPTION
## Summary
- remove variable references from the AzureRM backend blocks
- document that backend credentials should be provided via environment variables or backend-config values
- extend the same backend guidance to the common configuration

## Testing
- terraform -chdir=infra-core/dev init -backend=false *(fails: terraform binary unavailable in execution environment)*
- terraform -chdir=infra-core/prod init -backend=false *(fails: terraform binary unavailable in execution environment)*
- terraform -chdir=infra-core/common init -backend=false *(fails: terraform binary unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce09904508833282b652027e9cd98d