### PR TITLE
Refactor backend configuration handling for infra-core

### DIFF
--- a/infra-core/common/backend.tfvars.example
+++ b/infra-core/common/backend.tfvars.example
@@ -1,5 +1,7 @@
-subscription_id  = "<subscription-id>"
-tenant_id        = "<tenant-id>"
-client_id        = "<client-id>"
-client_secret    = "<client-secret>"
-use_azuread_auth = true
+# Copy this file to backend.tfvars and update the values for your environment.
+# Do not commit the generated backend.tfvars file to version control.
+resource_group_name  = "TerraformStorageAccount"
+storage_account_name = "terrsaform"
+container_name       = "terraform"
+key                  = "infra-core-common.tfstate"
+use_azuread_auth     = true

--- a/infra-core/common/versions.tf
+++ b/infra-core/common/versions.tf
@@ -9,15 +9,9 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "TerraformStorageAccount"
-    storage_account_name = "terrsaform"
-    container_name       = "terraform"
-    key                  = "infra-core-common.tfstate"
-
-    # The backend uses Azure AD authentication. Copy `backend.tfvars.example`
-    # to `backend.tfvars` (or export the equivalent environment variables)
+    # Backend settings are supplied via `terraform init -backend-config=backend.tfvars`.
+    # Copy `backend.tfvars.example` to `backend.tfvars` and populate the values
     # before running `terraform init`.
-    use_azuread_auth = true
   }
 }
 

--- a/infra-core/dev/backend.tfvars.example
+++ b/infra-core/dev/backend.tfvars.example
@@ -1,5 +1,7 @@
-subscription_id  = "<subscription-id>"
-tenant_id        = "<tenant-id>"
-client_id        = "<client-id>"
-client_secret    = "<client-secret>"
-use_azuread_auth = true
+# Copy this file to backend.tfvars and update the values for your environment.
+# Do not commit the generated backend.tfvars file to version control.
+resource_group_name  = "TerraformStorageAccount"
+storage_account_name = "terrsaform"
+container_name       = "terraform"
+key                  = "infra-core-dev.tfstate"
+use_azuread_auth     = true

--- a/infra-core/dev/versions.tf
+++ b/infra-core/dev/versions.tf
@@ -9,15 +9,9 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "TerraformStorageAccount"
-    storage_account_name = "terrsaform"
-    container_name       = "terraform"
-    key                  = "infra-core-dev.tfstate"
-
-    # The backend uses Azure AD authentication. Copy `backend.tfvars.example`
-    # to `backend.tfvars` (or export the equivalent environment variables)
+    # Backend settings are supplied via `terraform init -backend-config=backend.tfvars`.
+    # Copy `backend.tfvars.example` to `backend.tfvars` and populate the values
     # before running `terraform init`.
-    use_azuread_auth = true
   }
 }
 

--- a/infra-core/prod/backend.tfvars.example
+++ b/infra-core/prod/backend.tfvars.example
@@ -1,5 +1,7 @@
-subscription_id  = "<subscription-id>"
-tenant_id        = "<tenant-id>"
-client_id        = "<client-id>"
-client_secret    = "<client-secret>"
-use_azuread_auth = true
+# Copy this file to backend.tfvars and update the values for your environment.
+# Do not commit the generated backend.tfvars file to version control.
+resource_group_name  = "TerraformStorageAccount"
+storage_account_name = "terrsaform"
+container_name       = "terraform"
+key                  = "infra-core-prod.tfstate"
+use_azuread_auth     = true

--- a/infra-core/prod/versions.tf
+++ b/infra-core/prod/versions.tf
@@ -9,15 +9,9 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "TerraformStorageAccount"
-    storage_account_name = "terrsaform"
-    container_name       = "terraform"
-    key                  = "infra-core-prod.tfstate"
-
-    # The backend uses Azure AD authentication. Copy `backend.tfvars.example`
-    # to `backend.tfvars` (or export the equivalent environment variables)
+    # Backend settings are supplied via `terraform init -backend-config=backend.tfvars`.
+    # Copy `backend.tfvars.example` to `backend.tfvars` and populate the values
     # before running `terraform init`.
-    use_azuread_auth = true
   }
 }
 


### PR DESCRIPTION
## Summary
- rely on external backend configuration files for infra-core Terraform states
- refresh backend.tfvars examples to document storage account settings without embedding secrets

## Testing
- terraform fmt -recursive
- terraform init -backend=false (infra-core/common)
- terraform validate (infra-core/common)
- terraform init -backend=false (infra-core/dev)
- terraform validate (infra-core/dev)
- terraform init -backend=false (infra-core/prod)
- terraform validate (infra-core/prod)


------
https://chatgpt.com/codex/tasks/task_e_68cedd9cb25c8332af6eddf0b0811f9d